### PR TITLE
fixed  the revert scan message

### DIFF
--- a/src/laser_feature_ros.cpp
+++ b/src/laser_feature_ros.cpp
@@ -36,13 +36,27 @@ void LaserFeatureROS::compute_bearing(const sensor_msgs::LaserScan::ConstPtr &sc
 	std::vector<double> bearings, cos_bearings, sin_bearings;
 	std::vector<unsigned int> index;
 	unsigned int i = 0;
-	for (double b = scan_msg->angle_min; b <= scan_msg->angle_max; b += scan_msg->angle_increment)
+	if( scan_msg.angle_increment < 0)
+	{	
+		for (double b = scan_msg->angle_min; b >= scan_msg->angle_max; b += scan_msg->angle_increment)
+		{
+			bearings.push_back(b);
+			cos_bearings.push_back(cos(b));
+	    	sin_bearings.push_back(sin(b));
+	    	index.push_back(i);
+	    	i++;
+		}
+	}
+	else
 	{
-		bearings.push_back(b);
-		cos_bearings.push_back(cos(b));
-    	sin_bearings.push_back(sin(b));
-    	index.push_back(i);
-    	i++;
+		for (double b = scan_msg->angle_min; b <= scan_msg->angle_max; b += scan_msg->angle_increment)
+		{
+			bearings.push_back(b);
+			cos_bearings.push_back(cos(b));
+	    	sin_bearings.push_back(sin(b));
+	    	index.push_back(i);
+	    	i++;
+		}
 	}
 
 	line_feature_.setCosSinData(bearings, cos_bearings, sin_bearings, index);


### PR DESCRIPTION
rostopic  echo /scan 
header: 
  seq: 72339
  stamp: 
    secs: 1694170297
    nsecs: 334361646
  frame_id: "laser"
angle_min: 3.1415927410125732
angle_max: -3.1415927410125732
angle_increment: -0.005235987715423107
time_increment: 5.263152706902474e-05
scan_time: 0.0631578341126442
range_min: 0.0
range_max: 50.0